### PR TITLE
Post 조회, 생성 기능 추가

### DIFF
--- a/src/main/java/com/blog/controller/PostController.java
+++ b/src/main/java/com/blog/controller/PostController.java
@@ -1,0 +1,25 @@
+package com.blog.controller;
+
+import com.blog.dto.response.post.PostResponse;
+import com.blog.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/post")
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostResponse> findById(@PathVariable(value = "postId") Long postId) {
+        PostResponse response = postService.findById(postId);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/blog/controller/PostController.java
+++ b/src/main/java/com/blog/controller/PostController.java
@@ -1,13 +1,11 @@
 package com.blog.controller;
 
+import com.blog.dto.request.post.PostCreateRequest;
 import com.blog.dto.response.post.PostResponse;
 import com.blog.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/post")
 @RestController
@@ -19,6 +17,12 @@ public class PostController {
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponse> findById(@PathVariable(value = "postId") Long postId) {
         PostResponse response = postService.findById(postId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<PostResponse> save(@RequestBody PostCreateRequest request) {
+        PostResponse response = postService.create(1L, request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/blog/domain/BaseEntity.java
+++ b/src/main/java/com/blog/domain/BaseEntity.java
@@ -16,9 +16,9 @@ import java.time.LocalDateTime;
 public abstract class BaseEntity {
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime modifiedAt;
+    protected LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/blog/domain/Post.java
+++ b/src/main/java/com/blog/domain/Post.java
@@ -1,13 +1,18 @@
 package com.blog.domain;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+
+import java.time.LocalDateTime;
 
 import static javax.persistence.FetchType.*;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {
 
     @Id @GeneratedValue
@@ -21,5 +26,13 @@ public class Post extends BaseEntity {
 
     @Lob
     private String content;
+
+    public Post(User user, String title, String content) {
+        this.user = user;
+        this.title = title;
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+        this.modifiedAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/com/blog/dto/request/post/PostCreateRequest.java
+++ b/src/main/java/com/blog/dto/request/post/PostCreateRequest.java
@@ -1,0 +1,13 @@
+package com.blog.dto.request.post;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostCreateRequest {
+
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/blog/dto/response/post/PostResponse.java
+++ b/src/main/java/com/blog/dto/response/post/PostResponse.java
@@ -1,0 +1,29 @@
+package com.blog.dto.response.post;
+
+import com.blog.domain.Post;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class PostResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private Long userId;
+
+    public static PostResponse of(Post post) {
+        return new PostResponse(post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getCreatedAt(),
+                post.getModifiedAt(),
+                post.getUser().getId());
+    }
+}

--- a/src/main/java/com/blog/service/PostService.java
+++ b/src/main/java/com/blog/service/PostService.java
@@ -1,8 +1,11 @@
 package com.blog.service;
 
 import com.blog.domain.Post;
+import com.blog.domain.User;
+import com.blog.dto.request.post.PostCreateRequest;
 import com.blog.dto.response.post.PostResponse;
 import com.blog.repository.PostRepository;
+import com.blog.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,14 +16,32 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
 
     public PostResponse findById(Long postId) {
         Post post = find(postId);
         return PostResponse.of(post);
     }
 
+    @Transactional
+    public PostResponse create(Long userId, PostCreateRequest request) {
+        Post post = createPost(userId, request);
+        return PostResponse.of(post);
+    }
+
     protected Post find(Long postId) {
         return postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저"));
+    }
+
+    protected Post createPost(Long userId, PostCreateRequest request) {
+        User user = getUser(userId);
+        Post post = new Post(user, request.getTitle(), request.getContent());
+        return postRepository.save(post);
     }
 }

--- a/src/main/java/com/blog/service/PostService.java
+++ b/src/main/java/com/blog/service/PostService.java
@@ -1,0 +1,26 @@
+package com.blog.service;
+
+import com.blog.domain.Post;
+import com.blog.dto.response.post.PostResponse;
+import com.blog.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostRepository postRepository;
+
+    public PostResponse findById(Long postId) {
+        Post post = find(postId);
+        return PostResponse.of(post);
+    }
+
+    protected Post find(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글"));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL5Dialect

--- a/src/test/java/com/blog/http/http-client.env.json
+++ b/src/test/java/com/blog/http/http-client.env.json
@@ -1,0 +1,5 @@
+{
+  "dev": {
+    "host": "http://localhost:8080"
+  }
+}

--- a/src/test/java/com/blog/http/post.http
+++ b/src/test/java/com/blog/http/post.http
@@ -1,0 +1,3 @@
+###
+GET {{host}}/api/post/7
+Accept: application/json

--- a/src/test/java/com/blog/service/PostServiceTest.java
+++ b/src/test/java/com/blog/service/PostServiceTest.java
@@ -22,4 +22,18 @@ class PostServiceTest {
         assertThat(findPost.getId()).isEqualTo(7L);
     }
 
+    @Test
+    @Transactional
+    void 게시글_작성() {
+        Post createdPost = postService.createPost(1L, createPostCreateRequest());
+
+        Post findPost = postService.find(createdPost.getId());
+
+        assertThat(createdPost.getId()).isEqualTo(findPost.getId());
+    }
+
+    private PostCreateRequest createPostCreateRequest() {
+        return new PostCreateRequest("title-test", "content-test");
+    }
+
 }

--- a/src/test/java/com/blog/service/PostServiceTest.java
+++ b/src/test/java/com/blog/service/PostServiceTest.java
@@ -1,0 +1,25 @@
+package com.blog.service;
+
+import com.blog.domain.Post;
+import com.blog.dto.request.post.PostCreateRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class PostServiceTest {
+
+    @Autowired
+    PostService postService;
+
+    @Test
+    @Transactional
+    void 게시글_조회() {
+        Post findPost = postService.find(7L);
+        assertThat(findPost.getId()).isEqualTo(7L);
+    }
+
+}


### PR DESCRIPTION
Controller, Service, Repository, Entity 구조

Controller
- save post 시 하드코딩으로 user 정보를 넘기고 있음(user 기능 미구현 상태에서 우선은 강제로 user key를 넘기도록 구현)
- request and response 시 dto를 활용하여 엔드포인트 format 별도 처리

Service
- test 코드 활용을 위해 일부 메서드 access level을 protected로 선언

Repository, Entity 기존 구현 정보와 동일

추가
- update, delete 기능 추가 예정
- controller request에 대한 테스트를 위해 http 테스트 추가 예정